### PR TITLE
Install Google Tag Manager

### DIFF
--- a/frontend/app/entry/client/index.js
+++ b/frontend/app/entry/client/index.js
@@ -13,6 +13,7 @@ import configureApolloClient from 'state/configureApolloClient';
 import configureClientStore from 'state/configureClientStore';
 import { apiVersion, queryMap } from 'api';
 import introspectionData from 'introspection.json';
+import TagManager from 'react-gtm-module';
 import Root from './root';
 
 /* eslint-disable no-underscore-dangle,no-undef */
@@ -33,6 +34,11 @@ const mountNode = global.document.getElementById('app');
 
 // Encapsulate rendering for hot-reloading.
 const render: Function = (Component): void => {
+  const tagManagerArgs = {
+    gtmId: 'GTM-NFNDVJW',
+  };
+
+  TagManager.initialize(tagManagerArgs);
   ReactDOM.render(
     <Component store={reduxStore} client={apolloClient} />,
     mountNode,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "react": "^15.6.1",
     "react-apollo": "^1.4.8",
     "react-dom": "^15.6.1",
+    "react-gtm-module": "^2.0.8",
     "react-helmet": "^5.1.3",
     "react-hot-loader": "next",
     "react-pdf-js": "^2.0.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8481,6 +8481,7 @@ prop-types@^15.6.1:
 prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
@@ -8742,6 +8743,11 @@ react-dom@^15.6.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-gtm-module@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.8.tgz#0d37c4f2a4e3a8efa40c76c8b2aa1b7cacc16c6f"
+  integrity sha512-OU5FwAHC3gWnnxJ+MLwBMLZO1Pmn1DiVCGHqptwDnNojE3QRrNxjqozkW5cNS4Zp+C6HZ8a4ZIt0QPNlpzua4Q==
 
 react-helmet@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
#51 - This PR provides a mechanism for installing google tag manager (which installed Google Analytics).  Quick explanation of how this works: 

1. This PR adds the `GTM-NFNDVJW` google tag manager container into the application.
2. That GTM container has a GA tag that is triggered on `All Pages` and `History Change`. 
  -  `All Pages` fires on the initial page load
  - ` History Change` fires when subsequent links are clicked on within the single-page app. 
    ![image](https://user-images.githubusercontent.com/5263371/65658797-c01f5480-dfee-11e9-85fc-8666c8462726.png)
3. The `{{ GA - Settings }}` variable uses default settings for now, but sets the tracking ID based on the `{{ GA - Tracking ID }}` variable
    ![image](https://user-images.githubusercontent.com/5263371/65658827-e3e29a80-dfee-11e9-87ef-c427973849db.png)
4. The `{{ GA - Tracking ID }}` variable is simple lookup table.  If the user is currently on the `production` environment it uses `UA-148719863-1`, otherwise it fails over to the dev tracking ID `UA-148719863-2` (so our local development efforts don't hinder things)
    ![image](https://user-images.githubusercontent.com/5263371/65658846-fb218800-dfee-11e9-9d96-682a057a08f8.png)
5. The ``{{ Environment }}` variable is a simple hostname lookup. If `2019.texascamp.org` then it sets the environment to `production`, otherwise it sets it to `development`. 
    ![image](https://user-images.githubusercontent.com/5263371/65658897-2a37f980-dfef-11e9-8a2e-bbaeaa1f5255.png)

